### PR TITLE
fix: make ignoreArrayOrder recursive for nested collections

### DIFF
--- a/jsonpatch.go
+++ b/jsonpatch.go
@@ -202,43 +202,33 @@ func matchesValue(av, bv any, ignoreArrayOrder bool) bool {
 		}
 
 		if ignoreArrayOrder {
-			// Check if arrays have the same elements, regardless of order
-			// Create a map of element counts for each array
-			atCount := make(map[string]int)
-			btCount := make(map[string]int)
-
-			// Count elements in first array
-			for _, v := range at {
-				// Convert element to Json string for comparison
-				jsonBytes, err := json.Marshal(v)
-				if err != nil {
-					return false
+			// Recursive multiset equality. An earlier implementation serialised
+			// each element with json.Marshal and compared the multiset of
+			// resulting byte strings. json.Marshal sorts map keys but preserves
+			// array order, so a difference in nested-list ordering inside an
+			// element caused elements with semantically-equal content to hash
+			// to distinct keys, producing a false inequality at this level.
+			//
+			// Instead, pair each element of at with an unused element of bt
+			// whose content is deeply equal ignoring array order. O(n*m) in
+			// the worst case, correct for arbitrary nesting depth.
+			matched := make([]bool, len(bt))
+			for _, ea := range at {
+				found := false
+				for j, eb := range bt {
+					if matched[j] {
+						continue
+					}
+					if matchesValue(ea, eb, ignoreArrayOrder) {
+						matched[j] = true
+						found = true
+						break
+					}
 				}
-				jsonStr := string(jsonBytes)
-				atCount[jsonStr]++
-			}
-
-			// Count elements in second array
-			for _, v := range bt {
-				jsonBytes, err := json.Marshal(v)
-				if err != nil {
-					return false
-				}
-				jsonStr := string(jsonBytes)
-				btCount[jsonStr]++
-			}
-
-			// Compare counts
-			if len(atCount) != len(btCount) {
-				return false
-			}
-
-			for k, v := range atCount {
-				if btCount[k] != v {
+				if !found {
 					return false
 				}
 			}
-
 			return true
 		}
 		// Order matters, check each element in order

--- a/jsonpatch_recursive_set_test.go
+++ b/jsonpatch_recursive_set_test.go
@@ -1,0 +1,120 @@
+package jsonpatch
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestMatchesValue_RecursiveSetEquality covers the core invariant of the
+// default list-as-set semantics: two lists must compare equal whenever
+// their elements form the same multiset, *including* when individual
+// elements contain nested collections whose order happens to differ.
+//
+// Prior to the recursive fix, matchesValue serialised each element via
+// json.Marshal and compared the multiset of resulting byte strings.
+// json.Marshal sorts map keys (good) but preserves array order (bad for
+// us), so a nested list-ordering difference propagated out as a false
+// inequality on the outer element comparison.
+func TestMatchesValue_NestedArrayOrderingInsideElement(t *testing.T) {
+	a := []any{
+		map[string]any{
+			"Name":    "grafana",
+			"Ports":   []any{float64(3000), float64(4318)},
+			"Env":     []any{map[string]any{"Name": "X"}, map[string]any{"Name": "Y"}},
+		},
+		map[string]any{"Name": "mimir", "Ports": []any{float64(9009)}},
+	}
+	b := []any{
+		map[string]any{"Name": "mimir", "Ports": []any{float64(9009)}},
+		map[string]any{
+			"Name":    "grafana",
+			"Ports":   []any{float64(4318), float64(3000)},
+			"Env":     []any{map[string]any{"Name": "Y"}, map[string]any{"Name": "X"}},
+		},
+	}
+
+	assert.True(t, matchesValue(a, b, true),
+		"lists should compare equal: same multiset of elements, nested collections only differ by order")
+}
+
+// TestMatchesValue_NestedArrayContentDifferenceStillDetected guards the
+// negative direction: if a nested list in an element has a real content
+// difference (not just reordering), matchesValue must return false.
+func TestMatchesValue_NestedArrayContentDifferenceStillDetected(t *testing.T) {
+	a := []any{
+		map[string]any{"Name": "grafana", "Ports": []any{float64(3000), float64(4318)}},
+	}
+	b := []any{
+		map[string]any{"Name": "grafana", "Ports": []any{float64(3000), float64(9999)}},
+	}
+
+	assert.False(t, matchesValue(a, b, true),
+		"different nested content must still be detected as inequality")
+}
+
+// TestMatchesValue_NestedMapValueDifferenceStillDetected guards the
+// negative direction for nested maps as well.
+func TestMatchesValue_NestedMapValueDifferenceStillDetected(t *testing.T) {
+	a := []any{
+		map[string]any{"Name": "grafana", "Meta": map[string]any{"Role": "admin"}},
+	}
+	b := []any{
+		map[string]any{"Name": "grafana", "Meta": map[string]any{"Role": "viewer"}},
+	}
+
+	assert.False(t, matchesValue(a, b, true),
+		"different nested map content must still be detected as inequality")
+}
+
+// TestMatchesValue_DifferentLengthsAreUnequal keeps the length short-circuit
+// working.
+func TestMatchesValue_DifferentLengthsAreUnequal(t *testing.T) {
+	a := []any{map[string]any{"Name": "grafana"}}
+	b := []any{map[string]any{"Name": "grafana"}, map[string]any{"Name": "mimir"}}
+
+	assert.False(t, matchesValue(a, b, true),
+		"lists of different lengths are not equal")
+}
+
+// TestMatchesValue_DuplicatesAreMultisetSensitive ensures duplicate
+// elements are counted as a multiset, not a set — [A, A] != [A, B].
+func TestMatchesValue_DuplicatesAreMultisetSensitive(t *testing.T) {
+	a := []any{
+		map[string]any{"Name": "grafana"},
+		map[string]any{"Name": "grafana"},
+	}
+	b := []any{
+		map[string]any{"Name": "grafana"},
+		map[string]any{"Name": "mimir"},
+	}
+
+	assert.False(t, matchesValue(a, b, true),
+		"multiset semantics: duplicated elements should not match against distinct elements")
+}
+
+// TestMatchesValue_DeepNestingIsSymmetric ensures matching is symmetric
+// — matchesValue(a, b) == matchesValue(b, a) — even across arbitrary depth.
+func TestMatchesValue_DeepNestingIsSymmetric(t *testing.T) {
+	a := []any{
+		map[string]any{
+			"Outer": []any{
+				map[string]any{
+					"Inner": []any{float64(1), float64(2), float64(3)},
+				},
+			},
+		},
+	}
+	b := []any{
+		map[string]any{
+			"Outer": []any{
+				map[string]any{
+					"Inner": []any{float64(3), float64(2), float64(1)},
+				},
+			},
+		},
+	}
+
+	assert.True(t, matchesValue(a, b, true), "a vs b")
+	assert.True(t, matchesValue(b, a, true), "b vs a — symmetric")
+}


### PR DESCRIPTION
## Summary

\`matchesValue\`'s \`ignoreArrayOrder=true\` branch for \`[]any\` compared list elements by \`json.Marshal\` bytes. \`json.Marshal\` sorts map keys (good) but preserves array order (bad for set semantics), so an element whose nested-list contents happened to be in a different order produced a different byte string. The outer list-as-set comparison then reported false even when the two lists were semantically equivalent multisets.

## Impact

Downstream: formae's patch generator uses \`CreatePatch\` to decide whether a resource has changed. AWS-shaped resources with lists of structured sub-resources (e.g. \`ECS::TaskDefinition.ContainerDefinitions\`, each containing its own \`Environment\` and \`PortMappings\` lists) hit this on every reapply when the cloud API returns the nested lists in a canonicalised order different from the user-authored forma. Because the outer list sits under a \`createOnly\` path, the spurious add/remove ops triggered a full resource replacement — in the load-test case, a 5–10 minute destroy-and-recreate of a running ECS Service on every otherwise-idempotent reapply.

## Change

Replace the multiset-of-byte-strings check with a pairing algorithm that matches each element of the first list against an unused element of the second using \`matchesValue\` recursively. O(n*m) in the worst case; correct for arbitrary nesting depth. The symmetric negative cases (real content differences, length mismatches, multiset-sensitive duplicates) are preserved and covered by new tests.

## Tests

New file \`jsonpatch_recursive_set_test.go\`:

- \`TestMatchesValue_NestedArrayOrderingInsideElement\` — the reproducer. Two lists of container-shaped elements where the nested \`Ports\` and \`Env\` sub-lists are in different orders across the two sides. Previously returned false; now returns true.
- \`TestMatchesValue_DeepNestingIsSymmetric\` — nested arrays inside nested objects inside nested arrays, verifying symmetry (a vs b ≡ b vs a).
- \`TestMatchesValue_NestedArrayContentDifferenceStillDetected\` — guards the negative direction: a genuine content difference in a nested array must still return false.
- \`TestMatchesValue_NestedMapValueDifferenceStillDetected\` — same negative guard for nested map value differences.
- \`TestMatchesValue_DifferentLengthsAreUnequal\` — length short-circuit preserved.
- \`TestMatchesValue_DuplicatesAreMultisetSensitive\` — multiset semantics: \`[A, A]\` must not match \`[A, B]\`.

Full existing suite (\`go test ./...\`) stays green.

## Note

\`processSet\` (used by \`compareArray\`'s default branch to enumerate which elements need add/remove when \`matchesValue\` returns false) still uses \`json.Marshal\`-based lookup. With this fix, the fast path \`if len(av) == len(bv) && matchesValue(av, bv, true) { return retval }\` now correctly short-circuits whenever the lists are semantically equal, so \`processSet\` is only reached for lists that truly differ — and its purpose in that case is to emit ops (not to gate equality), where index imprecision is acceptable. A follow-up could align \`processSet\` with the recursive semantics for consistency, but it isn't required to fix the downstream regression.